### PR TITLE
fix: 🐛 turn off `spaced-comment` rule for react-app-env.d.ts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: "airbnb-typescript-prettier",
   rules: {
-    "spaced-comment": ["error", "always", { "markers": ["/"] }],
-  }
+    "spaced-comment": ["error", "always", { markers: ["/"] }],
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: "airbnb-typescript-prettier",
+  rules: {
+    "spaced-comment": ["error", "always", { "markers": ["/"] }],
+  }
 };


### PR DESCRIPTION
I've added an exception for a triple-slash as it's breaking `react-app-env.d.ts`