### PR TITLE
feat: adds Sablier branded colour scheme

### DIFF
--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -4,12 +4,12 @@ import { theme as gnosisTheme } from "@gnosis.pm/safe-react-components";
 const theme: DefaultTheme = gnosisTheme;
 theme.colors = {
   ...theme.colors,
-  primary: "#02d396",
-  primaryHover: "#00c58a",
-  primaryLight: "#d5f6ed",
-  secondary: "#966aed",
-  secondaryHover: "#8253dd",
-  secondaryLight: "#ebe1fb",
+  primary: "#f77423",
+  primaryHover: "#ec6816",
+  primaryLight: "#ff7f28",
+  secondary: "#1469ff",
+  secondaryHover: "#2357ec",
+  secondaryLight: "#0099ff",
 };
 
 export default theme;


### PR DESCRIPTION
I've added the Sablier orange and blue to the custom theme

| Color | Value  |
|---|---|
|primary   | Orange  | 
|  primaryHover | #00c58a |
| primaryLight  | Orange Pantone |
|secondary   | Blue  |  
|  secondaryHover | #2357ec  |  
| secondaryLight  | Blue Light  |  

Named colours are from the [Notion](https://www.notion.so/Colors-504d2755631840068e0d73d2e12dc6a5). For the "Hover" variants I picked a value which looked correct in testing.

closes #29