### PR TITLE
revert: rename "Sablier Safe App" to "Sablier"

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sablier Safe App",
+  "name": "Sablier",
   "description": "Safe App for interacting with the Sablier protocol",
   "icons": [
     {


### PR DESCRIPTION
This value is pulled and displayed in the Gnosis UI as so. Adding "Safe App" is inconsistent with other apps and a bit redundant

![Screenshot_2020-06-09_16-50-38](https://user-images.githubusercontent.com/15848336/84170387-89e90e80-aa71-11ea-9bd3-4f36fdda768c.png)
.