### PR TITLE
feat: set homepage in package.json to allow ipfs deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@sablier/safe-app",
   "description": "Safe App for interacting with the Sablier protocol",
   "version": "1.0.0",
+  "homepage": "./",
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
This is a fix for a known issue with IPFS deployments as the `/ipfs/[hash]` suffix screws up `index.html` loading assets

See: https://fauna.com/blog/serve-your-faunadb-single-page-app-from-ipfs