### PR TITLE
build: use react-app-rewired to inject headers into dev config

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,25 @@
+module.exports = {
+  webpack: function (config, env) {
+    return config;
+  },
+  jest: function (config) {
+    return config;
+  },
+  devServer: function (configFunction) {
+    return function (proxy, allowedHost) {
+      const config = configFunction(proxy, allowedHost);
+
+      config.headers = {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers":
+          "X-Requested-With, content-type, Authorization",
+      };
+
+      return config;
+    };
+  },
+  paths: function (paths, env) {
+    return paths;
+  },
+};

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "known-css-properties": "^0.19.0",
     "lint-staged": "^10.2.7",
     "prettier": "1.x",
+    "react-app-rewired": "^2.1.6",
     "react-scripts": "3.4.1",
     "shx": "^0.3.2",
     "stylelint": "^13.5.0",
@@ -90,14 +91,14 @@
   "scripts": {
     "precommit": "lint-staged",
     "commit": "git-cz",
-    "build": "react-scripts build",
+    "build": "react-app-rewired build",
     "clean": "shx rm -rf ./build",
     "eject": "react-scripts eject",
     "lint": "eslint --config ./.eslintrc.js --ignore-path ./.eslintignore src/**/*.{ts,tsx}",
     "lint:styles": "stylelint --config ./.stylelintrc.js './src/**/*.{css,ts,tsx,scss}'",
     "prettier": "prettier --config .prettierrc --write '**/*.{js,json,jsx,md,ts,tsx}'",
     "prettier:list-different": "prettier --config .prettierrc --list-different '**/*.{js,json,jsx,md,ts,tsx}'",
-    "start": "react-scripts start"
+    "start": "react-app-rewired start"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10895,6 +10895,13 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
+react-app-rewired@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.1.6.tgz#33ee3076a7f34d6a7c94e649cac67e7c8c580de8"
+  integrity sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==
+  dependencies:
+    semver "^5.6.0"
+
 react-dev-utils@^10.2.1:
   version "10.2.1"
   resolved "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz#f6de325ae25fa4d546d09df4bb1befdc6dd19c19"


### PR DESCRIPTION
This PR uses `react-app-rewired` to remove the need for devs to manually add headers to the dev server config in node_modules.

fixes #48